### PR TITLE
Randomize database fetch order

### DIFF
--- a/youtube/server.js
+++ b/youtube/server.js
@@ -493,6 +493,8 @@ async function scrapeNotScrapedChannels() {
         let offset = 0;
         let batchNumber = 1;
         let totalProcessed = 0;
+        const randomSeed = `${Date.now()}_${Math.floor(Math.random() * 1000000)}`;
+        console.log(`Randomizing database fetch order with seed: ${randomSeed}`);
 
         while (true) {
             const normalizedOffsetCandidate = Math.floor(Number(offset));
@@ -501,8 +503,11 @@ async function scrapeNotScrapedChannels() {
                     ? 0
                     : normalizedOffsetCandidate;
             const selectOffset = normalizedOffset;
-            const [rows] = await connection.query(
-                `SELECT url, query FROM not_scraped_channels ORDER BY url LIMIT ${batchSize} OFFSET ${selectOffset}`
+            const [rows] = await connection.execute(
+                `SELECT url, query FROM not_scraped_channels
+                ORDER BY MD5(CONCAT_WS('#', url, ?, query))
+                LIMIT ? OFFSET ?`,
+                [randomSeed, batchSize, selectOffset]
             );
 
             if (!rows.length) {


### PR DESCRIPTION
## Summary
- randomize the order of records pulled from `not_scraped_channels` by seeding a deterministic hash per run
- log the seed being used so parallel scraper instances can be correlated during debugging

## Testing
- not run (project has no automated tests)


------
https://chatgpt.com/codex/tasks/task_b_68c9e7d157b8832b9ef3c9afbaa1db1a