### PR TITLE
Improve Docker build reliability

### DIFF
--- a/youtube/.dockerignore
+++ b/youtube/.dockerignore
@@ -1,0 +1,6 @@
+node_modules
+npm-debug.log
+Dockerfile
+.dockerignore
+.git
+.gitignore

--- a/youtube/Dockerfile
+++ b/youtube/Dockerfile
@@ -1,20 +1,17 @@
-# Use an official Node.js runtime as a parent image
-FROM node:20-alpine
+# syntax=docker/dockerfile:1
 
-# Set the working directory inside the container
+FROM node:20-bookworm-slim AS deps
 WORKDIR /usr/src/app
 
-# Copy package.json and package-lock.json
 COPY package*.json ./
-
-# Install production dependencies
 RUN npm ci --omit=dev
 
-# Copy the rest of the application code
+FROM node:20-bookworm-slim AS runner
+WORKDIR /usr/src/app
+ENV NODE_ENV=production
+
+COPY --from=deps /usr/src/app/node_modules ./node_modules
 COPY . .
 
-# Expose the port the app runs on
 EXPOSE 3021
-
-# Start the server
 CMD ["node", "server.js"]


### PR DESCRIPTION
## Summary
- switch to a multi-stage Docker build based on node:20-bookworm-slim to install production dependencies cleanly
- copy the prepared node_modules directory into the runtime layer and expose the HTTP server
- add a .dockerignore file so host artifacts such as node_modules do not overwrite the container dependencies

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_b_68caeba96084832bb5a0c8943c630a45